### PR TITLE
Update doc to exclude all node_modules files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ module.exports = {
   plugins: [
     new CircularDependencyPlugin({
       // exclude detection of files based on a RegExp
-      exclude: /a\.js/,
+      exclude: /a\.js|node_modules/,
       // add errors to webpack instead of warnings
       failOnError: true
     })


### PR DESCRIPTION
Not necessary, but it could merit a default include somewhere so that error's aren't thrown in files that you don't own. Just a thought.