### PR TITLE
Add summary option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ module.exports = {
   ]
 }
 ```
+
+### Options
+
+Specified in the plugins section of webpack.config.js. (See above example code.)
+
+* exclude - A regular expression that defines which files/directories will be omitted from evaluation. If omitted, defaults to evaluating all JS-compilable files in the project path.
+* failOnError - If specified true, then any circular dependencies found will cause a Webpack build error. If specified false or omitted, circular dependencies will only generate warnings.
+* outputFormat - If specified "summary", a one-line summary description will be output in the event of any circular dependencies. If specified "full" or omitted, a complete description of circular dependencies will be output.

--- a/__tests__/index_test.js
+++ b/__tests__/index_test.js
@@ -94,6 +94,31 @@ describe('circular dependency', () => {
     });
   });
 
+  it('summarizes output to one line with outputFormat of "summary"', (done) => {
+    var fs = new MemoryFS();
+    var c = webpack({
+      entry: path.join(__dirname, 'deps/d.js'),
+      output: { path: __dirname },
+      plugins: [ new CircularDependencyPlugin({
+        outputFormat: 'summary'
+      }) ]
+    });
+
+    c.outputFileSystem = fs;
+
+    c.run(function(err, stats){
+      if (err) {
+        assert(false, err);
+        done();
+      } else {
+        stats = stats.toJson()
+        assert(stats.warnings.length === 1);
+        assert(stats.warnings[0] === '3 circular dependencies detected.')
+        done();
+      }
+    });
+  });
+
   it('can exclude cyclical deps from being output', (done) => {
     var s = sandbox.stub(console, 'warn', console.warn);
     var fs = new MemoryFS();


### PR DESCRIPTION
Hello, Aaron! 

I'm not sure if you are accepting PRs, but I would be happy if you were able to include this one. The issue it addresses for my team is that sometimes we just want a quick one-line summary to warn us of circular dependencies and other times we want the full output. So I added a "summary" option to do this, and updated unit tests and readme.md correspondingly.

In any case, I would like to thank you for your open source generosity with circular-dependency-plugin. It's useful and simply written.