### PR TITLE
Pass module into onDetected

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ class CircularDependencyPlugin {
             if (plugin.options.onDetected) {
               try {
                 plugin.options.onDetected({
+                  module: module,
                   paths: maybeCyclicalPathsList,
                   compilation: compilation
                 })


### PR DESCRIPTION
Module object can be required to add exclude logic into onDetected