### PR TITLE
Add minimum node version to engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "description": "Detect modules with circular dependencies when bundling with webpack.",
   "version": "4.2.0",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "dependencies": {},
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Hi, not sure if you find any need to merge this, but here it is anyway. Might save some minutes from someone.
We had one environment still using node v5 and after upgrading this plugin from 2.x to 4.1.0. it stopped working since node <6.0.0 doesn't yet support the syntax. Just a little helper to avoid confusion. 