### PR TITLE
Add option to allow cycles that include an asynchronous dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ module.exports = {
       exclude: /a\.js|node_modules/,
       // add errors to webpack instead of warnings
       failOnError: true,
+      // allow import cycles that include an asyncronous import,
+      // e.g. via import(/* webpackMode: "weak" */ './file.js')
+      allowAsyncCycles: true,
       // set the current working directory for displaying module paths
       cwd: process.cwd(),
     })

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class CircularDependencyPlugin {
     this.options = extend({
       exclude: new RegExp('$^'),
       failOnError: false,
+      allowAsyncCycles: true,
       onDetected: false,
       cwd: process.cwd()
     }, options)
@@ -82,6 +83,8 @@ class CircularDependencyPlugin {
       if (!depModule) { continue }
       // ignore dependencies that don't have an associated resource
       if (!depModule.resource) { continue }
+      // ignore dependencies that are resolved asynchronously
+      if (this.options.allowAsyncCycles && dependency.weak) { continue }
 
       if (depModule.debugId in seenModules) {
         if (depModule.debugId === initialModule.debugId) {


### PR DESCRIPTION
When using this plugin in conjunction with [babel-plugin-universal-import](https://github.com/faceyspacey/babel-plugin-universal-import) and [react-universal-component](https://github.com/faceyspacey/react-universal-component), this plugin generates warnings for import cycles even if one of the imports in the cycle is an asynchronous `import()` promise. This happens because of the `require.resolveWeak` used by babel-plugin-universal-import - it generates a dependency on the module in webpack (with the `weak`) flag set.

I've confirmed [here](https://github.com/hedgepigdaniel/webpack-universal-import-scratchpad) that even on the server when `import()` promises do not create separate chunks, the actual execution of the imported module is still asynchronous in the sense that it occurs after the module importing it has finished executing.

So this flag should prevent generating warnings where there is no risk that imports will be undefined as a result of import cycles.