### PR TITLE
Add includes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ module.exports = {
     new CircularDependencyPlugin({
       // exclude detection of files based on a RegExp
       exclude: /a\.js|node_modules/,
+      // include specific files based on a RegExp
+      include: /dir/,
       // add errors to webpack instead of warnings
       failOnError: true,
       // allow import cycles that include an asyncronous import,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -96,6 +96,28 @@ describe('circular dependency', () => {
     expect(stats.warnings[1]).toMatch(/g\.js/)
   })
 
+  it('can include only specific cyclical deps in the output', async () => {
+    let fs = new MemoryFS()
+    let compiler = webpack({
+      mode: 'development',
+      entry: path.join(__dirname, 'deps/d.js'),
+      output: { path: __dirname },
+      plugins: [
+        new CircularDependencyPlugin({
+          include: /f\.js/
+        })
+      ]
+    })
+    compiler.outputFileSystem = fs
+
+    let runAsync = wrapRun(compiler.run.bind(compiler))
+    let stats = await runAsync()
+    stats.warnings.forEach(warning => {
+      const firstFile = warning.match(/\w+\.js/)[0]
+      expect(firstFile).toMatch(/f\.js/)
+    })
+  })
+
   it(`can handle context modules that have an undefined resource h -> i -> a -> i`, async () => {
     let fs = new MemoryFS()
     let compiler = webpack({

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ class CircularDependencyPlugin {
   constructor(options) {
     this.options = extend({
       exclude: new RegExp('$^'),
+      include: new RegExp('.*'),
       failOnError: false,
       allowAsyncCycles: false,
       onDetected: false,
@@ -26,7 +27,8 @@ class CircularDependencyPlugin {
         for (let module of modules) {
           const shouldSkip = (
             module.resource == null ||
-            plugin.options.exclude.test(module.resource)
+            plugin.options.exclude.test(module.resource) ||
+            !plugin.options.include.test(module.resource)
           )
           // skip the module if it matches the exclude pattern
           if (shouldSkip) {


### PR DESCRIPTION
When working in a repository with many circular dependencies it is often to narrow the scope to just a specific directory.  I've implemented something similar to this function myself in the `onDetected` method, but I thought others might benefit from this as well.

Thanks for the great package. Hope you are interested in the feature.