### PR TITLE
Replace cycle detection algorithm with Tarjan's strongly connected components algorithm

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -57,11 +57,8 @@ for (let version of versions) {
       let stats = await runAsync()
 
       let msg0 = getWarningMessage(stats, 0)
-      let msg1 = getWarningMessage(stats, 1)
       expect(msg0).toContain('__tests__/deps/b.js -> __tests__/deps/c.js -> __tests__/deps/b.js')
       expect(msg0).toMatch(/Circular/)
-      expect(msg1).toMatch(/b\.js/)
-      expect(msg1).toMatch(/c\.js/)
     })
 
     it('detects circular dependencies from d -> e -> f -> g -> e', async () => {
@@ -78,12 +75,8 @@ for (let version of versions) {
       let stats = await runAsync()
 
       let msg0 = getWarningMessage(stats, 0)
-      let msg1 = getWarningMessage(stats, 1)
       expect(msg0).toContain('__tests__/deps/e.js -> __tests__/deps/f.js -> __tests__/deps/g.js -> __tests__/deps/e.js')
       expect(msg0).toMatch(/Circular/)
-      expect(msg1).toMatch(/e\.js/)
-      expect(msg1).toMatch(/f\.js/)
-      expect(msg1).toMatch(/g\.js/)
     })
 
     it('uses errors instead of warnings with failOnError', async () => {
@@ -102,12 +95,8 @@ for (let version of versions) {
       let stats = await runAsync()
 
       let err0 = getErrorsMessage(stats, 0)
-      let err1 = getErrorsMessage(stats, 1)
       expect(err0).toContain('__tests__/deps/e.js -> __tests__/deps/f.js -> __tests__/deps/g.js -> __tests__/deps/e.js')
       expect(err0).toMatch(/Circular/)
-      expect(err1).toMatch(/e\.js/)
-      expect(err1).toMatch(/f\.js/)
-      expect(err1).toMatch(/g\.js/)
     })
 
     it('can exclude cyclical deps from being output', async () => {
@@ -128,10 +117,7 @@ for (let version of versions) {
       let stats = await runAsync()
 
       let msg0 = getWarningMessage(stats, 0)
-      let msg1 = getWarningMessage(stats, 1)
       expect(msg0).toMatch(/Circular/)
-      expect(msg1).toMatch(/e\.js/)
-      expect(msg1).toMatch(/g\.js/)
     })
 
     it('can include only specific cyclical deps in the output', async () => {
@@ -227,10 +213,10 @@ for (let version of versions) {
       let runAsync = wrapRun(compiler.run.bind(compiler))
       await runAsync()
       expect(cyclesPaths).toEqual([
-        '__tests__/deps/g.js',
         '__tests__/deps/e.js',
         '__tests__/deps/f.js',
-        '__tests__/deps/g.js'
+        '__tests__/deps/g.js',
+        '__tests__/deps/e.js',
       ])
     })
 
@@ -254,11 +240,7 @@ for (let version of versions) {
       let stats = await runAsync()
 
       let msg0 = getWarningMessage(stats, 0)
-      let msg1 = getWarningMessage(stats, 1)
       expect(msg0).toContain('__tests__/deps/e.js -> __tests__/deps/f.js -> __tests__/deps/g.js -> __tests__/deps/e.js')
-      expect(msg1).toMatch(/e\.js/)
-      expect(msg1).toMatch(/f\.js/)
-      expect(msg1).toMatch(/g\.js/)
     })
 
     it('can detect circular dependencies when the ModuleConcatenationPlugin is used', async () => {
@@ -278,9 +260,7 @@ for (let version of versions) {
       let stats = await runAsync()
 
       let msg0 = getWarningMessage(stats, 0)
-      let msg1 = getWarningMessage(stats, 1)
       expect(msg0).toContain('__tests__/deps/module-concat-plugin-compat/a.js -> __tests__/deps/module-concat-plugin-compat/b.js -> __tests__/deps/module-concat-plugin-compat/a.js')
-      expect(msg1).toContain('__tests__/deps/module-concat-plugin-compat/b.js -> __tests__/deps/module-concat-plugin-compat/a.js -> __tests__/deps/module-concat-plugin-compat/b.js')
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 let path = require('path')
 let extend = require('util')._extend
+let Graph = require('tarjan-graph')
 let BASE_ERROR = 'Circular dependency detected:\r\n'
 let PluginTitle = 'CircularDependencyPlugin'
 
@@ -24,98 +25,77 @@ class CircularDependencyPlugin {
         if (plugin.options.onStart) {
           plugin.options.onStart({ compilation });
         }
+        const dependencyGraph = new Graph()
+        //console.log('LENGTH', modules.length);
         for (let module of modules) {
-          const shouldSkip = (
-            module.resource == null ||
-            plugin.options.exclude.test(module.resource) ||
-            !plugin.options.include.test(module.resource)
-          )
-          // skip the module if it matches the exclude pattern
-          if (shouldSkip) {
-            continue
-          }
 
-          let maybeCyclicalPathsList = this.isCyclic(module, module, {}, compilation)
-          if (maybeCyclicalPathsList) {
-            // allow consumers to override all behavior with onDetected
-            if (plugin.options.onDetected) {
-              try {
-                plugin.options.onDetected({
-                  module: module,
-                  paths: maybeCyclicalPathsList,
-                  compilation: compilation
-                })
-              } catch(err) {
-                compilation.errors.push(err)
-              }
-              continue
-            }
-
-            // mark warnings or errors on webpack compilation
-            let error = new Error(BASE_ERROR.concat(maybeCyclicalPathsList.join(' -> ')))
-            if (plugin.options.failOnError) {
-              compilation.errors.push(error)
+          // Iterate over the current modules dependencies
+          const dependedModuleIds = [];
+          for (let dependency of module.dependencies) {
+            let depModule = null
+            if (compilation.moduleGraph) {
+              // handle getting a module for webpack 5
+              depModule = compilation.moduleGraph.getModule(dependency)
             } else {
-              compilation.warnings.push(error)
+              // handle getting a module for webpack 4
+              depModule = dependency.module
             }
+
+            if (!depModule) { continue }
+
+            // ignore dependencies that don't have an associated resource
+            if (!depModule.resource) { continue }
+
+            // optionally ignore dependencies that are resolved asynchronously
+            if (this.options.allowAsyncCycles && dependency.weak) { continue }
+
+            dependedModuleIds.push(depModule.identifier());
           }
+          dependencyGraph.add(module.identifier(), dependedModuleIds)
         }
+
+        const cycles = dependencyGraph.getCycles();
+
+        cycles.forEach((vertices) => {
+          // Convert the array of vertices into an array of module paths
+          const cyclicPaths = vertices
+            .slice()
+            .reverse()
+            .map((vertex) => compilation.findModule(vertex.name).resource)
+            .filter((resource) => !(
+              resource == null ||
+              plugin.options.exclude.test(resource) ||
+              !plugin.options.include.test(resource)
+            ))
+            .map((resource) => path.relative(cwd, resource));
+
+          // allow consumers to override all behavior with onDetected
+          if (plugin.options.onDetected) {
+            try {
+              plugin.options.onDetected({
+                module: module,
+                paths: cyclicPaths.concat([cyclicPaths[0]]),
+                compilation: compilation
+              })
+            } catch(err) {
+              compilation.errors.push(err)
+            }
+            return
+          }
+
+          // mark warnings or errors on webpack compilation
+          let error = new Error(BASE_ERROR.concat(cyclicPaths.concat([cyclicPaths[0]]).join(' -> ')))
+          if (plugin.options.failOnError) {
+            compilation.errors.push(error)
+          } else {
+            compilation.warnings.push(error)
+          }
+        });
         if (plugin.options.onEnd) {
           plugin.options.onEnd({ compilation });
         }
       })
     })
-  }
-
-  isCyclic(initialModule, currentModule, seenModules, compilation) {
-    let cwd = this.options.cwd
-
-    // Add the current module to the seen modules cache
-    seenModules[currentModule.debugId] = true
-
-    // If the modules aren't associated to resources
-    // it's not possible to display how they are cyclical
-    if (!currentModule.resource || !initialModule.resource) {
-      return false
-    }
-
-    // Iterate over the current modules dependencies
-    for (let dependency of currentModule.dependencies) {
-      let depModule = null
-      if (compilation.moduleGraph) {
-        // handle getting a module for webpack 5
-        depModule = compilation.moduleGraph.getModule(dependency)
-      } else {
-        // handle getting a module for webpack 4
-        depModule = dependency.module
-      }
-
-      if (!depModule) { continue }
-      // ignore dependencies that don't have an associated resource
-      if (!depModule.resource) { continue }
-      // ignore dependencies that are resolved asynchronously
-      if (this.options.allowAsyncCycles && dependency.weak) { continue }
-
-      if (depModule.debugId in seenModules) {
-        if (depModule.debugId === initialModule.debugId) {
-          // Initial module has a circular dependency
-          return [
-            path.relative(cwd, currentModule.resource),
-            path.relative(cwd, depModule.resource)
-          ]
-        }
-        // Found a cycle, but not for this module
-        continue
-      }
-
-      let maybeCyclicalPathsList = this.isCyclic(initialModule, depModule, seenModules, compilation)
-      if (maybeCyclicalPathsList) {
-        maybeCyclicalPathsList.unshift(path.relative(cwd, currentModule.resource))
-        return maybeCyclicalPathsList
-      }
-    }
-
-    return false
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "testMatch": [
       "**/?(*.)(spec|test).js?(x)"
     ]
+  },
+  "dependencies": {
+    "tarjan-graph": "^2.0.0"
   }
 }


### PR DESCRIPTION
I noticed that this plugin was taking significant time (almost a second for a 5500 module project) to check for cycles in hot rebuilds. [Tarjan's strongly connected components algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm) as I understand is the fastest way to find dependency cycles. Its running time is linear in the number of vertices (modules) + edges (dependencies).

My best guess is that the existing algorithm is quadratic in the number of modules, because for each module in the compilation, all its dependencies are traversed recursively, which in the worst case also visits each module in the compilation.

I haven't done benchmarks, but in the same project after this change, this plugin is no longer perceptible in the ProgressPlugin output.

I also changed the output:
- One cycle is output only once, not separately for each file it contains
- For cycles when some modules in the cycle are excluded - it now outputs all modules in the cycle even if some are excluded. This makes more sense IMO, since otherwise it prints e.g. `a.js -> b.js` even if `a.js` does not directly import `b.js`, which is confusing. If all modules in a cycle are excluded, no warning is generated (I added a test to enforce this)