### PR TITLE
Faster is acyclic test

### DIFF
--- a/__tests__/is-acyclic.test.js
+++ b/__tests__/is-acyclic.test.js
@@ -1,0 +1,112 @@
+let { isAcyclic, depthFirstIterator } = require('../is-acyclic');
+
+
+function makeGraph(adjacencyList) {
+  const vertices = adjacencyList.map((v) => v[0]);
+  const arrow = (vertex) => {
+    for (const adj of adjacencyList)
+      if (adj[0] === vertex)
+        return adj[1];
+    throw new Error('invalid vertex: ' + vertex);
+  }
+  return {
+    vertices,
+    arrow,
+  }
+}
+
+
+describe('makeGraph', () => {
+  const graph = makeGraph([
+    ['u', ['v', 'x']],
+    ['v', ['y']],
+    ['w', ['y', 'z']],
+    ['x', ['v']],
+    ['y', ['x']],
+    ['z', ['z']],
+  ]);
+
+  it('constructs vertices', () => {
+    expect(graph.vertices).toEqual(['u', 'v', 'w', 'x', 'y', 'z'])
+  });
+
+  it('constructs arrow function', () => {
+    expect(graph.arrow('u')).toEqual(['v', 'x'])
+    expect(graph.arrow('v')).toEqual(['y'])
+    expect(graph.arrow('w')).toEqual(['y', 'z'])
+    expect(graph.arrow('x')).toEqual(['v'])
+    expect(graph.arrow('y')).toEqual(['x'])
+    expect(graph.arrow('z')).toEqual(['z'])
+  });
+})
+
+
+describe('depthFirstIterator', () => {
+
+  const graph = makeGraph([
+    ['u', ['v', 'x']],
+    ['v', ['y']],
+    ['w', ['y', 'z']],
+    ['x', ['v']],
+    ['y', ['x']],
+    ['z', ['z']],
+  ]);
+
+  it('traverses all vertices', () => {
+    vertices = new Set();
+    depthFirstIterator(
+      graph,
+      (vertex, adjacent) => vertices.add(vertex),
+      (u, v) => {},
+    )
+    expect(vertices).toEqual(new Set(graph.vertices));
+  });
+
+  it('follows this path', () => {
+    const path = [];
+    depthFirstIterator(
+      graph,
+      (vertex, adjacent) => path.push({ vertex, adjacent }),
+      (u, v) => path.push({ backEdge: [u, v] }),
+    )
+    expect(path).toEqual([
+      { vertex: 'u', adjacent: ['v', 'x'] },
+      { vertex: 'v', adjacent: ['y'] },
+      { vertex: 'y', adjacent: ['x'] },
+      { vertex: 'x', adjacent: ['v'] },
+      { backEdge: ['x', 'v'] },
+      { vertex: 'w', adjacent: ['y', 'z'] },
+      { vertex: 'z', adjacent: ['z'] },
+      { backEdge: ['z', 'z'] },
+    ]);
+  });
+});
+
+
+describe('isAcyclic', () => {
+
+  it('finds no cycle in tree', () => {
+    // note: adjacent vertices are alphabetically higher => tree graph
+    const graph = makeGraph([
+      ['u', ['v', 'x']],
+      ['v', ['y']],
+      ['w', ['y', 'z']],
+      ['x', []],
+      ['y', []],
+      ['z', []],
+    ]);
+    expect(isAcyclic(graph)).toBe(true);
+  });
+
+  it('finds cycle in complicated graph', () => {
+    const graph = makeGraph([
+      ['u', ['v', 'x']],
+      ['v', ['y']],
+      ['w', ['y', 'z']],
+      ['x', ['v']],
+      ['y', ['x']],
+      ['z', ['z']],
+    ]);
+    expect(isAcyclic(graph)).toBe(false);
+  });
+});

--- a/is-acyclic.js
+++ b/is-acyclic.js
@@ -1,0 +1,69 @@
+
+
+/**
+ * Test whether a directed graph is acyclic
+ *
+ * The graph is represented as a object { vertices, arrow } where
+ * - vertices is an array containing all vertices, and
+ * - arrow is a function mapping a tail vertex to the array of head vertices, that is,
+ *   the vertices at the head of each graph edge whose tail is the given vertex.
+ *
+ * For example:
+ *
+ *       x <- y <- z
+ *
+ * vertices == [x, y, z]    (order does not matter)
+ * arrow(x) == []
+ * arrow(y) == [x]
+ * arrow(z) == [y]
+ *
+ * See https://stackoverflow.com/questions/261573/best-algorithm-for-detecting-cycles-in-a-directed-graph
+ */
+function isAcyclic(graph) {
+  let isAcyclic = true;
+  depthFirstIterator(
+    graph,
+    () => {},
+    (backEdge) => isAcyclic = false);
+  return isAcyclic;
+}
+
+
+/**
+ * Depth-first traversal of the graph
+ *
+ * The visitor function is called with vertex, adjacent vertices
+ * The backEdge function is called with head, tail of a back edge
+ */
+function depthFirstIterator(graph, visitorFn, backEdgeFn) {
+  const discovered = new Set();
+  const finished = new Set();
+  for (const vertex of graph.vertices) {
+    if (!(discovered.has(vertex) || finished.has(vertex)))
+      depthFirstVisitor(vertex, discovered, finished, graph, visitorFn, backEdgeFn)
+  }
+}
+
+
+function depthFirstVisitor(vertex, discovered, finished, graph, visitorFn, backEdgeFn) {
+  discovered.add(vertex)
+  const adjacent = graph.arrow(vertex);  // the adjacent vertices in the direction of the edges
+  visitorFn(vertex, adjacent);
+
+  for (const v of adjacent) {
+    if (discovered.has(v)) {
+      backEdgeFn(vertex, v);
+    } else {
+      if (!finished.has(v))
+        depthFirstVisitor(v, discovered, finished, graph, visitorFn, backEdgeFn)
+    }
+  }
+  discovered.delete(vertex)
+  finished.add(vertex)
+}
+
+
+module.exports = {
+  isAcyclic,
+  depthFirstIterator,
+}


### PR DESCRIPTION
This branch implements the fast acyclic test based on the depth first search. If there are cycles then the old algorithm is used, in particular the output stays the same.

In my project (5000+ webpack modules) this speeds up the circular dependency check from about 4300ms to 30ms (of course only if there are no cycles, if there are then nothing changes)
