### PR TITLE
Spread options to fix DeprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 let path = require('path')
-let extend = require('util')._extend
 let BASE_ERROR = 'Circular dependency detected:\r\n'
 let PluginTitle = 'CircularDependencyPlugin'
 
 class CircularDependencyPlugin {
   constructor(options) {
-    this.options = extend({
+    this.options = {
       exclude: new RegExp('$^'),
       include: new RegExp('.*'),
       failOnError: false,
       allowAsyncCycles: false,
       onDetected: false,
-      cwd: process.cwd()
-    }, options)
+      cwd: process.cwd(),
+      ...options
+    }
   }
 
   apply(compiler) {


### PR DESCRIPTION
Fixes this DeprecationWarning:
```
DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
    at new CircularDependencyPlugin (/node_modules/circular-dependency-plugin/index.js:8:20)
```