### PR TITLE
fix: The `util._extend` API is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 let path = require('path')
-let extend = require('util')._extend
+let extend = Object.assign
 let BASE_ERROR = 'Circular dependency detected:\r\n'
 let PluginTitle = 'CircularDependencyPlugin'
 


### PR DESCRIPTION
(node:48988) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.